### PR TITLE
Post release fix

### DIFF
--- a/post-release.sh
+++ b/post-release.sh
@@ -1,2 +1,3 @@
+npx sequelize-cli db:migrate:undo:all
 npx sequelize-cli db:migrate
 npx sequelize-cli db:seed:all


### PR DESCRIPTION
Adding npx sequelize-cli db:migrate:undo:all to the post-release.sh file to undo the double seeds that I have in my app right now.